### PR TITLE
Remove arrow function from parser.pegjs code

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ module.exports = (function() {
             if (a[0].type === 'range') {
               obj.answers = a[0].answer;
             } else {
-              obj.answers = a.map(obj => obj.answer);
+              obj.answers = a.map(function(obj){ return obj.answer});
             }
 
             // add properties for ranges

--- a/parser.pegjs
+++ b/parser.pegjs
@@ -52,7 +52,7 @@ Question
     if (a[0].type === 'range') {
       obj.answers = a[0].answer;
     } else {
-      obj.answers = a.map(obj => obj.answer);
+      obj.answers = a.map(function(obj){ return obj.answer});
     }
 
     // add properties for ranges


### PR DESCRIPTION
This will allow the generated `index.js` code to be included in environments that don't support arrow functions without an additional transpiling step.